### PR TITLE
🏗️ Cart entity만 관련된 컴포넌트 분리

### DIFF
--- a/src/refactoring/entity/cart/components/CartItem.tsx
+++ b/src/refactoring/entity/cart/components/CartItem.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { getMaxApplicableDiscount } from '@/refactoring/entity/cart/utils/cart';
+import type { CartItem as CartItemType } from '@/types';
+
+interface CartItemProps {
+  cart: CartItemType;
+  onIncreaseQuantity: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onDecreaseQuantity: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onRemoveCart: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+export const CartItem = ({ cart, onIncreaseQuantity, onDecreaseQuantity, onRemoveCart }: CartItemProps) => {
+  const appliedDiscount = getMaxApplicableDiscount(cart);
+
+  return (
+    <div className="flex items-center justify-between rounded bg-white p-3 shadow">
+      <div>
+        <span className="font-semibold">{cart.product.name}</span>
+        <br />
+        <span className="text-sm text-gray-600">
+          {cart.product.price}원 x {cart.quantity}
+          {appliedDiscount > 0 && (
+            <span className="ml-1 text-green-600">({(appliedDiscount * 100).toFixed(0)}% 할인 적용)</span>
+          )}
+        </span>
+      </div>
+      <div>
+        <button
+          onClick={onDecreaseQuantity}
+          className="mr-1 rounded bg-gray-300 px-2 py-1 text-gray-800 hover:bg-gray-400"
+        >
+          -
+        </button>
+        <button
+          onClick={onIncreaseQuantity}
+          className="mr-1 rounded bg-gray-300 px-2 py-1 text-gray-800 hover:bg-gray-400"
+        >
+          +
+        </button>
+        <button onClick={onRemoveCart} className="rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600">
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/refactoring/pages/CartPage.tsx
+++ b/src/refactoring/pages/CartPage.tsx
@@ -1,6 +1,6 @@
+import { CartItem } from '@/refactoring/entity/cart/components/CartItem';
 import { useCart } from '@/refactoring/entity/cart/hooks/useCart';
-import { getMaxApplicableDiscount } from '@/refactoring/entity/cart/utils/cart';
-import type { CartItem, Coupon, Product } from '@/types';
+import type { CartItem as CartItemType, Coupon, Product } from '@/types';
 
 interface Props {
   products: Product[];
@@ -14,7 +14,7 @@ export const CartPage = ({ products, coupons }: Props) => {
     return discounts.reduce((max, discount) => Math.max(max, discount.rate), 0);
   };
 
-  const getRemainingStock = (product: Product, cart: CartItem[]) => {
+  const getRemainingStock = (product: Product, cart: CartItemType[]) => {
     const cartItem = cart.find(item => item.product.id === product.id);
     return product.stock - (cartItem?.quantity || 0);
   };
@@ -83,41 +83,14 @@ export const CartPage = ({ products, coupons }: Props) => {
 
           <div className="space-y-2">
             {cart.map(item => {
-              const appliedDiscount = getMaxApplicableDiscount(item);
-
               return (
-                <div key={item.product.id} className="flex items-center justify-between rounded bg-white p-3 shadow">
-                  <div>
-                    <span className="font-semibold">{item.product.name}</span>
-                    <br />
-                    <span className="text-sm text-gray-600">
-                      {item.product.price}원 x {item.quantity}
-                      {appliedDiscount > 0 && (
-                        <span className="ml-1 text-green-600">({(appliedDiscount * 100).toFixed(0)}% 할인 적용)</span>
-                      )}
-                    </span>
-                  </div>
-                  <div>
-                    <button
-                      onClick={() => updateQuantity(item.product.id, item.quantity - 1)}
-                      className="mr-1 rounded bg-gray-300 px-2 py-1 text-gray-800 hover:bg-gray-400"
-                    >
-                      -
-                    </button>
-                    <button
-                      onClick={() => updateQuantity(item.product.id, item.quantity + 1)}
-                      className="mr-1 rounded bg-gray-300 px-2 py-1 text-gray-800 hover:bg-gray-400"
-                    >
-                      +
-                    </button>
-                    <button
-                      onClick={() => removeFromCart(item.product.id)}
-                      className="rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600"
-                    >
-                      삭제
-                    </button>
-                  </div>
-                </div>
+                <CartItem
+                  key={item.product.id}
+                  cart={item}
+                  onIncreaseQuantity={() => updateQuantity(item.product.id, item.quantity + 1)}
+                  onDecreaseQuantity={() => updateQuantity(item.product.id, item.quantity - 1)}
+                  onRemoveCart={() => removeFromCart(item.product.id)}
+                />
               );
             })}
           </div>


### PR DESCRIPTION
페이지 기준으로 되어 있는 코드에서 entity를 중심으로 분리하려 했습니다.
시작하기 전에는 cart ui 단위로 나누면 될 것 같았는데 의외로 product나 쿠폰을 쓰는 로직이 섞여 있어서 어떻게 분리해야 할지 정하기가 어려웠습니다. 
우선적으로 cart 데이터만 사용하는 것은 어떤 것인지 확인해보고 컴포넌트를 나누어보았습니다.